### PR TITLE
Update to Nibbles 4.0.4

### DIFF
--- a/org.gnome.Nibbles.json
+++ b/org.gnome.Nibbles.json
@@ -1,12 +1,16 @@
 {
     "app-id": "org.gnome.Nibbles",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.vala"
+    ],
     "command": "gnome-nibbles",
     "finish-args": [
         /* X11 + XShm access */
-        "--share=ipc", "--socket=fallback-x11",
+        "--share=ipc",
+        "--socket=fallback-x11",
         /* Wayland access */
         "--socket=wayland",
         /* Sound! */
@@ -14,8 +18,22 @@
         /* OpenGL access */
         "--device=dri"
     ],
-    "cleanup": ["/include", "/lib/*.la", "/lib/pkgconfig",
-                "/share/man", "/share/vala"],
+    "build-options": {
+        "prepend-path": "/usr/lib/sdk/vala/bin/",
+        "prepend-ld-library-path": "/usr/lib/sdk/vala/lib"
+    },
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "/share/vala",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name" : "gsound",
@@ -46,13 +64,29 @@
             ]
         },
         {
+            "name": "libgee",
+            "buildsystem": "autotools",
+            "build-options": {
+                "env": {
+                    "ACLOCAL_PATH" : "/usr/lib/sdk/vala/share/aclocal"
+                }
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libgee/0.20/libgee-0.20.6.tar.xz",
+                    "sha256": "1bf834f5e10d60cc6124d74ed3c1dd38da646787fbf7872220b8b4068e476d4d"
+                }
+            ]
+        },
+        {
             "name": "libgnome-games-support",
             "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgnome-games-support/1.8/libgnome-games-support-1.8.2.tar.xz",
-                    "sha256": "28434604a7b038731ac0231731388ff104f565bb2330cc24e78cda04cfd3ef7d"
+                    "url": "https://download.gnome.org/sources/libgnome-games-support/2.0/libgnome-games-support-2.0.0.tar.xz",
+                    "sha256": "53821f6fe32eddcb9eef3324f646aaac83cc6d3de0937dfd5f266470d453d2a4"
                 }
             ]
         },
@@ -61,9 +95,9 @@
             "buildsystem": "meson",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/gnome-nibbles.git",
-                    "commit": "8d07c0071a972654f58e41a858eafb2ef272a114"
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-nibbles/4.0/gnome-nibbles-4.0.4.tar.xz",
+                    "sha256": "d712a4c6943bf32956adfb9222f1f14369911e54ecebb0cd61f7c25abd7a59da"
                 }
             ]
         }


### PR DESCRIPTION
Update to Nibble 4.0.4. JSON copied from the development repository and adjusted as necessary.