### PR TITLE
Drop libgee module

### DIFF
--- a/org.gnome.Nibbles.json
+++ b/org.gnome.Nibbles.json
@@ -43,20 +43,6 @@
             ]
         },
         {
-            "name": "libgee",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgee/0.20/libgee-0.20.8.tar.xz",
-                    "sha256": "189815ac143d89867193b0c52b7dc31f3aa108a15f04d6b5dca2b6adfad0b0ee",
-                    "x-checker-data": {
-                        "type": "gnome",
-                        "name": "libgee"
-                    }
-                }
-            ]
-        },
-        {
             "name": "gnome-nibbles",
             "buildsystem": "meson",
             "config-opts": [


### PR DESCRIPTION
GNOME runtime provides the libgee module. It is no longer necessary to compile it, unless the project requires a specific version or dependency, or configuration of this dependency.

Fixes: https://github.com/flathub/org.gnome.Nibbles/issues/18